### PR TITLE
Refactor: 태그 컴포넌트 리팩토링

### DIFF
--- a/src/components/Tag/Tag.module.scss
+++ b/src/components/Tag/Tag.module.scss
@@ -1,38 +1,38 @@
 %tag-base {
-  @include flexbox;
+  @include inline-flexbox;
   @include text-style(12, $black50, bold);
 
-  width: 6.2rem;
+  min-width: 6.2rem;
   height: 2.2rem;
-  text-transform: uppercase;
+  padding: 0 0.8rem;
   border-radius: 0.4rem;
 }
 
 .tag {
-  &-offline {
+  &-default {
+    @extend %tag-base;
+
+    color: $white;
+    background-color: $tag-background;
+  }
+
+  &-primary {
     @extend %tag-base;
 
     background-color: $primary;
   }
 
-  &-online {
+  &-secondary {
     @extend %tag-base;
 
     color: $primary;
     background-color: $tag-background;
   }
 
-  &-clan-recruitment {
+  &-tertiary {
     @extend %tag-base;
 
     color: $purple20;
-    background-color: $tag-background;
-  }
-
-  &-game-strategy {
-    @extend %tag-base;
-
-    color: $white;
     background-color: $tag-background;
   }
 }

--- a/src/components/Tag/index.tsx
+++ b/src/components/Tag/index.tsx
@@ -1,19 +1,17 @@
 import classNames from 'classnames/bind';
 
-import { formatPostTypeToKR } from '@/utils';
-
-import { PostTypesEN } from '@/types';
-
 import styles from './Tag.module.scss';
+import { ReactNode } from 'react';
 
 const cx = classNames.bind(styles);
 
 type TagProps = {
-  postType: PostTypesEN | string;
+  children: ReactNode;
+  variant?: 'default' | 'primary' | 'secondary' | 'tertiary';
 };
 
-const Tag = ({ postType }: TagProps) => {
-  return <div className={cx(`tag-${postType}`)}>{formatPostTypeToKR(postType)}</div>;
+const Tag = ({ children, variant = 'default' }: TagProps) => {
+  return <div className={cx(`tag-${variant}`)}>{children}</div>;
 };
 
 export default Tag;


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 관련 문서
- issue: #
- close #
  
## 유형
- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성 
-->
- 태그 content를 children으로 받도록 변경되었습니다.
- variant 타입을 'default' | 'primary' | 'secondary' | 'tertiary'로 지정했습니다.
- 태그의 최소 너비를 지정하고, 초과되는 너비에 대해 padding 속성을 적용했습니다.

## 스크린샷 
![badge](https://github.com/sprint-team3/GGF-Design-System/assets/77719310/a3f36309-e074-4435-bf96-fbed3dbd123f)
